### PR TITLE
Arreglo de mala gramática

### DIFF
--- a/EdgeCut-1.0.0/index.html
+++ b/EdgeCut-1.0.0/index.html
@@ -246,7 +246,7 @@
             </div>
             <div class="detail-box">
               <h5>
-                Martin y Isabel, Huacachina
+                Martin e Isabel, Huacachina
               </h5>
               <div class="price_box">
                 <h6 class="price_heading">


### PR DESCRIPTION
En la parte de Martín Y Isabel, lo correcto era: Martín e Isabel